### PR TITLE
Fix/ GetTexture 함수 수정, LightComp AABB크기 수정

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/LightComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/LightComponent.cpp
@@ -3,8 +3,8 @@
 
 ULightComponentBase::ULightComponentBase()
 {
-    AABB.max = { 1.f,1.f,0.1f };
-    AABB.min = { -1.f,-1.f,-0.1f };
+    AABB.max = { 1.f,1.f,1.f };
+    AABB.min = { -1.f,-1.f,-1.f };
 }
 
 UObject* ULightComponentBase::Duplicate(UObject* InOuter)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/ResourceMgr.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/ResourceMgr.cpp
@@ -9,8 +9,9 @@
 #include "Engine/FLoaderOBJ.h"
 
 
-void FResourceMgr::Initialize(FRenderer* renderer, FGraphicsDevice* device)
+void FResourceMgr::Initialize(FRenderer* renderer, FGraphicsDevice* InDevice)
 {
+    device = InDevice;
     LoadTextureFromFile(device->Device, device->DeviceContext, L"Assets/Texture/font.png");
     LoadTextureFromDDS(device->Device, device->DeviceContext, L"Assets/Texture/font.dds");
     LoadTextureFromFile(device->Device, device->DeviceContext, L"Assets/Texture/T_Explosion_SubUV.png");
@@ -55,10 +56,20 @@ struct TupleHash {
     }
 };
 
-std::shared_ptr<FTexture> FResourceMgr::GetTexture(const FWString& name) const
+std::shared_ptr<FTexture> FResourceMgr::GetTexture(const FWString& name)
 {
-    auto* TempValue = textureMap.Find(name);
-    return TempValue ? *TempValue : nullptr;
+    if (textureMap.Contains(name))
+    {
+        return textureMap[name];
+    }
+    
+    HRESULT hr = LoadTextureFromFile(device->Device, device->DeviceContext, name.c_str());
+
+    if (SUCCEEDED(hr))
+    {
+        return textureMap[name];
+    }
+    return nullptr;
 }
 
 HRESULT FResourceMgr::LoadTextureFromFile(ID3D11Device* device, ID3D11DeviceContext* context, const wchar_t* filename)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/ResourceMgr.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/ResourceMgr.h
@@ -9,12 +9,13 @@ class FResourceMgr
 {
 
 public:
-    void Initialize(FRenderer* renderer, FGraphicsDevice* device);
+    void Initialize(FRenderer* renderer, FGraphicsDevice* InDevice);
     void Release(FRenderer* renderer);
     HRESULT LoadTextureFromFile(ID3D11Device* device, ID3D11DeviceContext* context, const wchar_t* filename);
     HRESULT LoadTextureFromDDS(ID3D11Device* device, ID3D11DeviceContext* context, const wchar_t* filename);
 
-    std::shared_ptr<FTexture> GetTexture(const FWString& name) const;
+    std::shared_ptr<FTexture> GetTexture(const FWString& name);
 private:
     TMap<FWString, std::shared_ptr<FTexture>> textureMap;
+    FGraphicsDevice* device;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorRenderPass.cpp
@@ -381,7 +381,7 @@ void FEditorRenderPass::CreateBuffers()
     }
 
     bufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
-    bufferDesc.ByteWidth = ConeIndices.Num() * sizeof(FVector);
+    bufferDesc.ByteWidth = ConeIndices.Num() * sizeof(uint32);
 
     initData.pSysMem = ConeIndices.GetData();
 


### PR DESCRIPTION
## 주요 변경사항

- GetTexture 함수 호출시 로드되지 않은 Texture일 경우 Texture 로드 시도하도록 수정
-  LightComponentBase AABB크기 수정 (기존 높이 값이 절반인 aabb 크기를 수정 -> 피킹 잘됨)
- bytewidth sizeof 수정